### PR TITLE
Implement `connection_state` proc macro for generating connection state management boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ rcgen = { version = "0.10.0", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 tracing = "0.1.37"
 rustls-native-certs = "0.6.2"
+hardlight-macros = { path = "macros" }
 
 [workspace]
 members = [
     ".",
-    "testing-project"
+    "testing-project",
+    "macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 tracing = "0.1.37"
 rustls-native-certs = "0.6.2"
 hardlight-macros = { path = "macros" }
+array-init = "2.0"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-# HardLight
+# HardLight [![Crates.io](https://img.shields.io/crates/v/hardlight)](https://crates.io/crates/hardlight) [![Docs.rs](https://docs.rs/hardlight/badge.svg)](https://docs.rs/hardlight)
 
 A secure, real-time, low-latency binary WebSocket RPC subprotocol.
 
-[![Crates.io](https://img.shields.io/crates/v/hardlight)](https://crates.io/crates/hardlight)
-[![Docs.rs](https://docs.rs/hardlight/badge.svg)](https://docs.rs/hardlight)
-
-**NOTE:** HardLight is currently in unstable development. The API, wire protocol and features are subject to change. See below for the current progress.
-
+**NOTE:** HardLight is currently in unstable development. The API, wire protocol and features are subject to change. See [below](#feature-tracking) for the current progress.
 
 ## What is HardLight?
 
@@ -27,7 +23,7 @@ While there isn't an official "specification", we take a similar approach to Bit
 
 All features will be completed for 1.0.0 apart from those marked with an asterisk.
 
-- [ ] RPC (from @617a7a)
+- [ ] RPC (from [@617a7a](https://github.com/617a7a))
   - [x] Connection state
     - [x] `connection_state` macro
     - [x] client state
@@ -44,7 +40,7 @@ All features will be completed for 1.0.0 apart from those marked with an asteris
   - [x] server
     - [x] version agreement
     - [x] run in background
-- [ ] Events (from @beast4coder)
+- [ ] Events (from [@beast4coder](https://github.com/beast4coder))
   - [ ] finish scoping out API **[IN PROGRESS]**
   - [x] wire support
   - [ ] client

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A secure, real-time, low-latency binary WebSocket RPC subprotocol.
 
+[![Crates.io](https://img.shields.io/crates/v/hardlight)](https://crates.io/crates/hardlight)
+[![Docs.rs](https://docs.rs/hardlight/badge.svg)](https://docs.rs/hardlight)
+
+**NOTE:** HardLight is currently in unstable development. The API, wire protocol and features are subject to change. See below for the current progress.
+
+
+## What is HardLight?
+
+HardLight is a binary WebSocket RPC subprotocol. It's designed to be faster (lower latencies, bigger capacity) than gRPC while being easier to use and secure by default. It's built on top of [rkyv](https://rkyv.org), a zero-copy deserialization library, and [tokio-tungstenite](https://github.com/snapview/tokio-tungstenite) (for server/client implementations).
+
 HardLight has two data models:
 
 - RPC: a client connects to a server, and can call functions on the server
@@ -12,6 +22,40 @@ An example: multiple clients subscribe to a "chat" event using Events. The conne
 HardLight is named after the fictional [Forerunner technology](https://www.halopedia.org/Hard_light) that "allows light to be transformed into a solid state, capable of bearing weight and performing a variety of tasks".
 
 While there isn't an official "specification", we take a similar approach to Bitcoin Core, where the protocol is defined by the implementation. This implementation should be considered the "reference implementation" of the protocol, and ports should match the behaviour of this implementation.
+
+### Feature tracking
+
+All features will be completed for 1.0.0 apart from those marked with an asterisk.
+
+- [ ] RPC (from @617a7a)
+  - [x] Connection state
+    - [x] `connection_state` macro
+    - [x] client state
+    - [x] mutex'd server state
+    - [x] server state autosync
+  - [ ] RPC macro **[IN PROGRESS]**
+    - [ ] `#[rpc(State)]` macro
+    - [ ] `#[rpc(State, Event)]` macro
+  - [ ] client
+    - [x] self-signed TLS
+    - [ ] wasm client*
+    - [x] version agreement
+    - [x] run in background
+  - [x] server
+    - [x] version agreement
+    - [x] run in background
+- [ ] Events (from @beast4coder)
+  - [ ] finish scoping out API **[IN PROGRESS]**
+  - [x] wire support
+  - [ ] client
+    - [ ] event hooks of some variation
+    - [ ] wasm client*
+  - [ ] server
+    - [ ] multi-connection topic management
+      - [ ] retrieve broadcast receivers from main server
+      - [ ] create topic handlers for server-scoped unique topics
+      - [ ] clean up topic handlers with no subscribers
+    - [ ] subscribe/unsubscribe a connection to a topic from server-side RPC handlers
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ At Valera, we use HardLight to connect clients to our servers, and for connectin
 
 ## Usage
 
-HardLight is designed to be simple, secure and fast. We take advantage of Rust's trait system to allow you to define your own RPC methods, and then use the `#[derive(RPC)]` macro to generate the necessary code to make it work.
+HardLight is designed to be simple, secure and fast. We take advantage of Rust's trait system to allow you to define your own RPC methods, and then use the `#[rpc(State)]` macro to generate the necessary code to make it work.
 
 Here's a very simple example of a counter service:
 
 ```rust
-use hardlight::{RPC, ConnectionState};
+use hardlight::{rpc, connection_state};
 
 /// These RPC methods are executed on the server and can be called by clients.
-#[derive(RPC)]
+#[rpc(State)]
 trait Counter {
     async fn increment(&self, amount: u32) -> u32;
     async fn decrement(&self, amount: u32) -> u32;
@@ -63,7 +63,7 @@ trait Counter {
 /// In reality, you'd probably want to store this in a database and use subscriptions
 /// to push updates to clients. Connection state is ephemeral (per connection)
 /// and is not persisted.
-#[derive(ConnectionState)]
+#[connection_state]
 struct State {
     counter: u32,
 }
@@ -71,7 +71,7 @@ struct State {
 
 The `Counter` trait is shared between clients and servers. Any inputs or outputs have to support rkyv's `Serialize`, `Deserialize`, `Archive` and `CheckBytes` traits. This means you can use any primitive type, or any type that implements these traits.
 
-The `#[derive(RPC)]` macro will generate:
+The `#[rpc(State)]` macro will generate:
 
 - a `Client` struct
 - a `Handler` struct

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hardlight-macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro-crate = "1.0"
+
+[lib]
+proc-macro = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -27,20 +27,20 @@ pub fn connection_state(_attr: TokenStream, input: TokenStream) -> TokenStream {
         #input_ast
 
         struct StateController {
-            state: std::sync::Mutex<#state_ident>,
+            state: parking_lot::Mutex<#state_ident>,
             channel: std::sync::Arc<tokio::sync::mpsc::Sender<Vec<(String, Vec<u8>)>>>,
         }
 
         impl StateController {
             fn new(channel: StateUpdateChannel) -> Self {
                 Self {
-                    state: std::sync::Mutex::new(Default::default()),
+                    state: parking_lot::Mutex::new(Default::default()),
                     channel: std::sync::Arc::new(channel),
                 }
             }
 
             fn lock(&self) -> StateGuard {
-                let state = self.state.lock().unwrap();
+                let state = self.state.lock();
                 StateGuard {
                     starting_state: state.clone(),
                     state,
@@ -50,7 +50,7 @@ pub fn connection_state(_attr: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         struct StateGuard<'a> {
-            state: std::sync::MutexGuard<'a, #state_ident>,
+            state: parking_lot::MutexGuard<'a, #state_ident>,
             starting_state: #state_ident,
             channel: std::sync::Arc<tokio::sync::mpsc::Sender<Vec<(String, Vec<u8>)>>>,
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,118 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_attribute]
+pub fn connection_state(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input_ast = parse_macro_input!(input as DeriveInput);
+    let state_ident = &input_ast.ident;
+    let (_, ty_generics, where_clause) = input_ast.generics.split_for_impl();
+
+    let field_names: Vec<_> = match input_ast.data {
+        syn::Data::Struct(ref data_struct) => data_struct
+            .fields
+            .iter()
+            .map(|f| f.ident.as_ref().unwrap())
+            .collect(),
+        _ => panic!("ConnectionState can only be derived on structs"),
+    };
+    
+    let field_strings: Vec<_> = field_names
+        .iter()
+        .map(|name| name.to_string())
+        .collect();
+
+    let expanded = quote! {
+        #[derive(Clone, Default, Debug)]
+        #input_ast
+
+        struct StateController {
+            state: std::sync::Mutex<#state_ident>,
+            channel: std::sync::Arc<tokio::sync::mpsc::Sender<Vec<(String, Vec<u8>)>>>,
+        }
+
+        impl StateController {
+            fn new(channel: StateUpdateChannel) -> Self {
+                Self {
+                    state: std::sync::Mutex::new(Default::default()),
+                    channel: std::sync::Arc::new(channel),
+                }
+            }
+
+            fn lock(&self) -> StateGuard {
+                let state = self.state.lock().unwrap();
+                StateGuard {
+                    starting_state: state.clone(),
+                    state,
+                    channel: self.channel.clone(),
+                }
+            }
+        }
+
+        struct StateGuard<'a> {
+            state: std::sync::MutexGuard<'a, #state_ident>,
+            starting_state: #state_ident,
+            channel: std::sync::Arc<tokio::sync::mpsc::Sender<Vec<(String, Vec<u8>)>>>,
+        }
+
+        impl<'a> Drop for StateGuard<'a> {
+            fn drop(&mut self) {
+                let mut changes = Vec::new();
+
+                #(
+                    if self.state.#field_names != self.starting_state.#field_names {
+                        changes.push((
+                            #field_strings.to_string(),
+                            rkyv::to_bytes::<_, 1024>(&self.state.#field_names).unwrap().to_vec(),
+                        ));
+                    }
+                )*
+
+                if changes.is_empty() {
+                    return;
+                }
+
+                let channel = self.channel.clone();
+                tokio::spawn(async move {
+                    let _ = channel.send(changes).await;
+                });
+            }
+        }
+
+        impl std::ops::Deref for StateGuard<'_> {
+            type Target = #state_ident;
+
+            fn deref(&self) -> &Self::Target {
+                &self.state
+            }
+        }
+
+        impl std::ops::DerefMut for StateGuard<'_> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.state
+            }
+        }
+
+        impl ClientState for #state_ident #ty_generics #where_clause {
+            fn apply_changes(
+                &mut self,
+                changes: Vec<(String, Vec<u8>)>,
+            ) -> HandlerResult<()> {
+                for (field, new_value) in changes {
+                    match field.as_ref() {
+                        #(
+                            #field_strings => {
+                                self.#field_names = rkyv::from_bytes(&new_value)
+                                    .map_err(|_| RpcHandlerError::BadInputBytes)?;
+                            }
+                        ),*
+                        _ => {}
+                    }
+                }
+                Ok(())
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,8 @@ use crate::{
     wire::{ClientMessage, RpcHandlerError, ServerMessage},
 };
 
+use array_init::array_init;
+
 pub struct ClientConfig {
     tls: TLSClientConfig,
     host: String,
@@ -36,7 +38,7 @@ pub struct ClientConfig {
 pub trait ClientState {
     fn apply_changes(
         &mut self,
-        changes: Vec<(String, Vec<u8>)>,
+        changes: Vec<(usize, Vec<u8>)>,
     ) -> HandlerResult<()>;
 }
 
@@ -141,7 +143,7 @@ where
             debug!("Control channels sent.");
 
             // keep track of active RPC calls
-            let mut active_rpc_calls: [Option<RpcResponseSender>; 256] = [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None];
+            let mut active_rpc_calls: [Option<RpcResponseSender>; 256] = array_init(|_| None);
 
             debug!("Starting RPC handler loop");
             loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@ mod server;
 mod wire;
 
 pub use client::*;
+pub use hardlight_macros::*;
 pub use server::*;
 pub use tokio_tungstenite::tungstenite;
 pub use wire::*;
-pub use hardlight_macros::*;
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct Topic(Vec<u8>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,31 @@ pub use client::*;
 pub use server::*;
 pub use tokio_tungstenite::tungstenite;
 pub use wire::*;
+pub use hardlight_macros::*;
+
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+pub struct Topic(Vec<u8>);
+
+impl Into<Vec<u8>> for Topic {
+    fn into(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl Into<Topic> for Vec<u8> {
+    fn into(self) -> Topic {
+        Topic(self)
+    }
+}
+
+impl Into<Topic> for &str {
+    fn into(self) -> Topic {
+        Topic(self.as_bytes().to_vec())
+    }
+}
+
+impl Into<Topic> for String {
+    fn into(self) -> Topic {
+        Topic(self.as_bytes().to_vec())
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,7 +27,7 @@ use crate::wire::{ClientMessage, RpcHandlerError, ServerMessage};
 
 /// A tokio MPSC channel that is used to send state updates to the runtime.
 /// The runtime will then send these updates to the client.
-pub type StateUpdateChannel = mpsc::Sender<Vec<(String, Vec<u8>)>>;
+pub type StateUpdateChannel = mpsc::Sender<Vec<(usize, Vec<u8>)>>;
 
 pub type HandlerResult<T> = Result<T, RpcHandlerError>;
 

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -43,7 +43,7 @@ pub enum ServerMessage {
         event: Vec<u8>,
     },
     /// The server updates the connection state.
-    StateChange(Vec<(String, Vec<u8>)>),
+    StateChange(Vec<(usize, Vec<u8>)>),
 }
 
 #[derive(Archive, Serialize, Deserialize, Debug)]

--- a/testing-project/src/main.rs
+++ b/testing-project/src/main.rs
@@ -5,14 +5,12 @@ use hardlight::{
     tungstenite, Client, ClientState, HandlerResult, RpcHandlerError,
     RpcResponseSender, Server, ServerConfig, ServerHandler, StateUpdateChannel,
 };
-use parking_lot::{Mutex, MutexGuard};
 use rkyv::{Archive, CheckBytes, Deserialize, Serialize};
 use tokio::select;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info};
 
 use std::{
-    ops::{Deref, DerefMut},
     sync::Arc,
 };
 
@@ -29,6 +27,7 @@ async fn main() -> Result<(), std::io::Error> {
     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
     let mut client = CounterClient::new_self_signed("localhost:8080");
+    // client.add_event_handler(EventMonitor::init()).await;
     client.connect().await.unwrap();
 
     let _ = client.increment(1).await;
@@ -86,6 +85,7 @@ async fn main() -> Result<(), std::io::Error> {
     Ok(())
 }
 
+// #[hardlight::RPC(State)]
 #[async_trait]
 trait Counter {
     async fn increment(&self, amount: u32) -> HandlerResult<u32>;
@@ -94,7 +94,7 @@ trait Counter {
     async fn get(&self) -> HandlerResult<u32>;
 }
 
-#[derive(Clone, Default, Debug)]
+#[hardlight::connection_state]
 struct State {
     counter: u32,
 }
@@ -191,6 +191,7 @@ impl CounterServer {
             None => {}
         }
     }
+    // pub async fn send(event: Event, topic: String) {}
 }
 
 /// RPC server that implements the [Counter] trait. A wrapper around
@@ -244,102 +245,6 @@ impl ServerHandler for Handler {
                 Ok(result.to_vec())
             }
         }
-    }
-}
-
-/// The StateController is a server-side wrapper around the user's state. It
-/// manages the state under a [parking_lot::Mutex] and stores a [mpsc::Sender]
-/// to send any changes. This is accessable through self.state for RPC
-/// functions.
-struct StateController {
-    /// State is locked under an internal mutex so multiple threads can
-    /// use it safely
-    state: Mutex<State>,
-    /// The channel is given by the runtime when it creates the connection,
-    /// allowing us to tell the runtime when the connection's state is modified
-    /// so it can send the changes to the client automatically
-    channel: Arc<mpsc::Sender<Vec<(String, Vec<u8>)>>>,
-}
-
-impl StateController {
-    fn new(channel: StateUpdateChannel) -> Self {
-        Self {
-            // use default values for the state
-            state: Mutex::new(Default::default()),
-            channel: Arc::new(channel),
-        }
-    }
-
-    /// Locks the state to the current RPC handler by issuing a StateGuard.
-    /// When the StateGuard is dropped, it'll send any changes to the client.
-    fn lock(&self) -> StateGuard {
-        let state = self.state.lock();
-        StateGuard {
-            starting_state: state.clone(),
-            state,
-            channel: self.channel.clone(),
-        }
-    }
-}
-
-/// StateGuard wraps MutexGuard to send any changes back to the runtime when
-/// it's dropped.
-struct StateGuard<'a> {
-    /// The StateGuard is given ownership of a lock to the state
-    state: MutexGuard<'a, State>,
-    /// A copy of the state before we locked it
-    /// We use this to compare changes when the StateGuard is dropped
-    starting_state: State,
-    /// A channel pointer that we can use to send changes to the runtime
-    /// which will handle sending them to the client
-    channel: Arc<mpsc::Sender<Vec<(String, Vec<u8>)>>>,
-}
-
-impl<'a> Drop for StateGuard<'a> {
-    /// Our custom drop implementation will send any changes to the runtime
-    fn drop(&mut self) {
-        // "diff" the two states to see what changed
-        let mut changes = Vec::new();
-
-        if self.state.counter != self.starting_state.counter {
-            changes.push((
-                "counter".to_string(),
-                rkyv::to_bytes::<u32, 1024>(&self.state.counter)
-                    .unwrap()
-                    .to_vec(),
-            ));
-        }
-
-        // if there are no changes, don't bother sending anything
-        if changes.is_empty() {
-            return;
-        }
-
-        // send the changes to the runtime
-        // we have to spawn a new task because we can't await inside a drop
-        let channel = self.channel.clone();
-        tokio::spawn(async move {
-            // this could fail if the server shuts down before these
-            // changes are sent... but we're not too worried about that
-            let _ = channel.send(changes).await;
-        });
-    }
-}
-
-// the Deref and DerefMut traits allow us to use the StateGuard as if it were a
-// State by derefing to the Mutex's deref impl. This allows us to do
-// things like state.counter instead of state.state.counter
-impl Deref for StateGuard<'_> {
-    type Target = State;
-
-    fn deref(&self) -> &Self::Target {
-        &self.state
-    }
-}
-
-impl DerefMut for StateGuard<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.state
     }
 }
 
@@ -473,23 +378,5 @@ impl Counter for CounterClient {
                 .map_err(|_| RpcHandlerError::BadOutputBytes),
             Err(e) => Err(e),
         }
-    }
-}
-
-impl ClientState for State {
-    fn apply_changes(
-        &mut self,
-        changes: Vec<(String, Vec<u8>)>,
-    ) -> HandlerResult<()> {
-        for (field, new_value) in changes {
-            match field.as_ref() {
-                "counter" => {
-                    self.counter = rkyv::from_bytes(&new_value)
-                        .map_err(|_| RpcHandlerError::BadInputBytes)?
-                }
-                _ => {}
-            }
-        }
-        Ok(())
     }
 }

--- a/testing-project/src/main.rs
+++ b/testing-project/src/main.rs
@@ -2,17 +2,16 @@
 // see: https://github.com/rust-lang/rust/issues/91611
 use async_trait::async_trait;
 use hardlight::{
-    tungstenite, Client, ClientState, HandlerResult, RpcHandlerError,
-    RpcResponseSender, Server, ServerConfig, ServerHandler, StateUpdateChannel,
+    connection_state, tungstenite, Client, ClientState, HandlerResult,
+    RpcHandlerError, RpcResponseSender, Server, ServerConfig, ServerHandler,
+    StateUpdateChannel,
 };
 use rkyv::{Archive, CheckBytes, Deserialize, Serialize};
 use tokio::select;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info};
 
-use std::{
-    sync::Arc,
-};
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
@@ -94,7 +93,7 @@ trait Counter {
     async fn get(&self) -> HandlerResult<u32>;
 }
 
-#[hardlight::connection_state]
+#[connection_state]
 struct State {
     counter: u32,
 }


### PR DESCRIPTION
Closes #11 

This pull request introduces the `connection_state `proc macro, which generates boilerplate code for managing the state of a connection in a multi-threaded environment. The macro generates a `StateController` and a `StateGuard` and implements the `ClientState` trait for the target struct, reducing the need for repetitive code and improving maintainability. 

This PR also changes how state changes are identified using `usize` to identify the modified field rather than sending the field name as a string.

Here is a brief overview of the macro's functionality:

- The `StateController` struct manages the state under a `parking_lot::Mutex` and stores a `mpsc::Sender` to send any changes.
- The `StateGuard` struct wraps a `MutexGuard` and sends changes back to the runtime when it's dropped via a clone of the parent controller's sender.
- The `ClientState` trait implementation updates the state with changes received from the server.

With this new macro, users can easily manage their application state by simply applying the `#[connection_state]` attribute to their struct.